### PR TITLE
Improved INA219 current measurement tasks

### DIFF
--- a/main/include/ina219.hpp
+++ b/main/include/ina219.hpp
@@ -1,5 +1,12 @@
 #pragma once
 
+#include "include/sdlog.hpp"
+
 #define INATAG "INA219"
 
-void taskCurrent(void *params_i2c_address);
+struct params_taskINA_t {
+  const int INA219_ADDR;
+  DataPacket* data;
+};
+
+void taskCurrent(void *params_ina219);

--- a/main/include/sdlog.hpp
+++ b/main/include/sdlog.hpp
@@ -10,6 +10,7 @@ typedef struct data_packet_t{
   uint8_t logging;
   int baro;
   float temp;
+  float bat_amp;
 } DataPacket;
 
 void logWriteHeader(FILE* file);

--- a/main/include/sdlog.hpp
+++ b/main/include/sdlog.hpp
@@ -10,7 +10,7 @@ typedef struct data_packet_t{
   uint8_t logging;
   int baro;
   float temp;
-  float bat_amp;
+  float bat_amp, elev_amp, ail_amp, rud_amp;
 } DataPacket;
 
 void logWriteHeader(FILE* file);

--- a/main/include/telemetry.hpp
+++ b/main/include/telemetry.hpp
@@ -8,7 +8,7 @@ typedef struct lora_packet{
   uint8_t logging;
   int baro;
   float temp;
-  float bat_amp;
+  float bat_amp, elev_amp, ail_amp, rud_amp;
 } LoraPacket;
 
 void taskLoRa_tx(void *pvParameters);

--- a/main/include/telemetry.hpp
+++ b/main/include/telemetry.hpp
@@ -8,6 +8,7 @@ typedef struct lora_packet{
   uint8_t logging;
   int baro;
   float temp;
+  float bat_amp;
 } LoraPacket;
 
 void taskLoRa_tx(void *pvParameters);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -64,7 +64,7 @@ extern "C" void app_main(void) {
 
   //INA_ELEVATOR
   static const struct params_taskINA_t INA_ELEV = {
-    INA219_ADDR_GND_GND, &datapacket};
+    INA219_ADDR_VS_GND, &datapacket};
 
   //INA_AILERON
   static const struct params_taskINA_t INA_AIL = {
@@ -72,7 +72,7 @@ extern "C" void app_main(void) {
 
   //INA_RUDDER
   static const struct params_taskINA_t INA_RUD = {
-    INA219_ADDR_VS_GND, &datapacket};
+    INA219_ADDR_GND_GND, &datapacket};
 
   // Voltage ADC
   // BAT_ELEC (adc range: 470-7660mV)
@@ -104,14 +104,14 @@ extern "C" void app_main(void) {
              (void *)&INA_RUD, 2, NULL);  // A1 bridged A0 open
 
   // Voltage measuring tasks (disabled due to sharing pins with LoRa)
-  // xTaskCreate(&taskVoltage, "read battery voltage",        // GPIO36 (= VP)
-  //             configMINIMAL_STACK_SIZE * 8, (void *)&BatteryElec, 2, NULL);
-  // xTaskCreate(&taskVoltage, "read regulator voltage",      // GPIO39 (= VN)
-  //             configMINIMAL_STACK_SIZE * 8, (void *)&BuckBoostElec, 2, NULL);
-  // xTaskCreate(&taskVoltage, "read DAQ battery voltage",    // GPIO33
-  //             configMINIMAL_STACK_SIZE * 8, (void *)&BatteryDAQ, 2, NULL);
-  // xTaskCreate(&taskVoltage, "read DAQ regulator voltage",  // GPIO34
-  //             configMINIMAL_STACK_SIZE * 8, (void *)&StepUpDAQ, 2, NULL);
+  xTaskCreate(&taskVoltage, "read battery voltage",        // GPIO36 (= VP)
+              configMINIMAL_STACK_SIZE * 8, (void *)&BatteryElec, 2, NULL);
+  xTaskCreate(&taskVoltage, "read regulator voltage",      // GPIO39 (= VN)
+              configMINIMAL_STACK_SIZE * 8, (void *)&BuckBoostElec, 2, NULL);
+  xTaskCreate(&taskVoltage, "read DAQ battery voltage",    // GPIO33
+              configMINIMAL_STACK_SIZE * 8, (void *)&BatteryDAQ, 2, NULL);
+  xTaskCreate(&taskVoltage, "read DAQ regulator voltage",  // GPIO34
+              configMINIMAL_STACK_SIZE * 8, (void *)&StepUpDAQ, 2, NULL);
 
   // BMP280 task (baro, temp)
   xTaskCreate(&taskBMP280, "BMP280 read", configMINIMAL_STACK_SIZE * 8,

--- a/main/src/ina219.cpp
+++ b/main/src/ina219.cpp
@@ -18,13 +18,17 @@
 #include "include/sdlog.hpp"
 
 // INA219 Current Sensor task
-void taskCurrent(void *params_i2c_address) {
+void taskCurrent(void *params_ina219) {
   ina219_t sensor;  // device struct
   memset(&sensor, 0, sizeof(ina219_t));
 
+  // retrieve data from parameter
+  int i2c_address = ((struct params_taskINA_t *)params_ina219)->INA219_ADDR;
+  DataPacket* datapacket = ((struct params_taskINA_t *)params_ina219)->data;
+
   ESP_ERROR_CHECK(ina219_init_desc( &sensor,
-                 (int)params_i2c_address,
-                 I2C_PORT, SDA_GPIO,SCL_GPIO));  // if fails (invalid address), aborts execution
+                 i2c_address, I2C_PORT,
+                 SDA_GPIO, SCL_GPIO));  // if fails (invalid address), aborts execution
   ESP_LOGI(INATAG, "Initializing INA219");
 
   // attempt initialization 5 times
@@ -33,13 +37,13 @@ void taskCurrent(void *params_i2c_address) {
     ESP_LOGE(INATAG,
               "Failed to initialize 0x%x. Is the wiring connected? "
               "(attempt %d/5)",
-              (int)params_i2c_address, attempt);
+              i2c_address, attempt);
     vTaskDelay(pdMS_TO_TICKS(5000));
     attempt++;
   }
   if (attempt > 5) {
     ESP_LOGE(INATAG, "Failed to initialize 0x%x, suspending task",
-             (int)params_i2c_address);
+             i2c_address);
     vTaskSuspend(NULL);
   }
   // if successful, take readings
@@ -56,9 +60,12 @@ void taskCurrent(void *params_i2c_address) {
     while (1) {
       ina219_get_current(&sensor, &current);
       printf("Current: %.04f mA, address: 0x%x\n", current * 1000,
-             (int)params_i2c_address);
+             i2c_address);
 
-    vTaskDelay(pdMS_TO_TICKS(500));
+    // write data to DataPacket
+    datapacket->bat_amp = current * 1000;
+
+    vTaskDelay(pdMS_TO_TICKS(100));
     }
   }
 }

--- a/main/src/ina219.cpp
+++ b/main/src/ina219.cpp
@@ -59,11 +59,24 @@ void taskCurrent(void *params_ina219) {
     ESP_LOGI(INATAG, "Starting the loop");
     while (1) {
       ina219_get_current(&sensor, &current);
-      printf("Current: %.04f mA, address: 0x%x\n", current * 1000,
-             i2c_address);
+      // printf("Current: %.04f mA, address: 0x%x\n", current * 1000,
+      //        i2c_address);
 
     // write data to DataPacket
-    datapacket->bat_amp = current * 1000;
+    switch(i2c_address){
+      case INA219_ADDR_VS_VS:
+        datapacket->bat_amp = current * 1000;
+        break;
+      case INA219_ADDR_VS_GND:
+        datapacket->elev_amp = current * 1000;
+        break;
+      case INA219_ADDR_GND_VS:
+        datapacket->ail_amp = current * 1000;
+        break;
+      case INA219_ADDR_GND_GND:
+        datapacket->rud_amp = current * 1000;
+        break;
+    }
 
     vTaskDelay(pdMS_TO_TICKS(100));
     }

--- a/main/src/sdlog.cpp
+++ b/main/src/sdlog.cpp
@@ -23,7 +23,15 @@
 
 // Write CSV file header
 void logWriteHeader(FILE* file){
-  fprintf(file, "PacketID,Timestamp,Baro,Temp\n");
+  fprintf(file, "PacketID,"
+                "Timestamp,"
+                "Baro,"
+                "Temp,"
+                "Bat_Amp,"
+                "Elev_Amp,"
+                "Ail_Amp,"
+                "Rud_Amp,"
+                "\n");
 }
 
 // Write data into CSV file
@@ -31,14 +39,18 @@ void logWrite(FILE* file, DataPacket* datapacket){
   // get timestamp in miliseconds
   ((DataPacket *)datapacket)->timestamp = esp_timer_get_time()/1000;
 
-  // Retrieve data from DataPacket
-  fprintf(file, "%d,", datapacket->packetid);
-  fprintf(file, "%lld,", datapacket->timestamp);
-  fprintf(file, "%d,", datapacket->baro);
-  fprintf(file, "%lf", datapacket->temp);
+  // Retrieve data from DataPacket and build a buffer string
+  std::string packetstr;
+  packetstr += std::to_string(datapacket->timestamp) + ",";
+  packetstr += std::to_string(datapacket->baro) + ",";
+  packetstr += std::to_string(datapacket->temp) + ",";
+  packetstr += std::to_string(datapacket->bat_amp) + ",";
+  packetstr += std::to_string(datapacket->elev_amp) + ",";
+  packetstr += std::to_string(datapacket->ail_amp) + ",";
+  packetstr += std::to_string(datapacket->rud_amp) + "\n";
 
-  // Print CRLF
-  fprintf(file, "\n");
+  // Write buffer string to file
+  fprintf(file, "%s", packetstr.c_str());
 }
 
 // Initialize SPI and mount SD card
@@ -154,7 +166,7 @@ void taskSD(void *datapacket){
       // increment number in filename and try to open again.
       // when it fails, that means the file does not exist, so open it
       // in write mode to create the file and start logging
-      if(!logging){
+      if(!logging){ // GPIO16 is pulled down, LOW = on
         do{
           fclose(file);
           attempt++;

--- a/main/src/telemetry.cpp
+++ b/main/src/telemetry.cpp
@@ -35,9 +35,10 @@ void taskLoRa_tx(void *pvParameters){
     // Build LoRa Packet
     LoraPacket lorapacket;
     lorapacket.packetid = ((DataPacket *)pvParameters)->packetid;
+    lorapacket.logging = ((DataPacket *)pvParameters)->logging;
     lorapacket.baro = ((DataPacket *)pvParameters)->baro;
     lorapacket.temp = ((DataPacket *)pvParameters)->temp;
-    lorapacket.logging = ((DataPacket *)pvParameters)->logging;
+    lorapacket.bat_amp = ((DataPacket *)pvParameters)->bat_amp;
 
     // Transmit packet
     lora_send_packet((uint8_t *)&lorapacket, sizeof(LoraPacket));

--- a/main/src/telemetry.cpp
+++ b/main/src/telemetry.cpp
@@ -39,6 +39,9 @@ void taskLoRa_tx(void *pvParameters){
     lorapacket.baro = ((DataPacket *)pvParameters)->baro;
     lorapacket.temp = ((DataPacket *)pvParameters)->temp;
     lorapacket.bat_amp = ((DataPacket *)pvParameters)->bat_amp;
+    lorapacket.elev_amp = ((DataPacket *)pvParameters)->elev_amp;
+    lorapacket.ail_amp = ((DataPacket *)pvParameters)->ail_amp;
+    lorapacket.rud_amp = ((DataPacket *)pvParameters)->rud_amp;
 
     // Transmit packet
     lora_send_packet((uint8_t *)&lorapacket, sizeof(LoraPacket));


### PR DESCRIPTION
Refactored INA219 tasks to pass sensor address as well as DataPacket as parameters to the task
Added INA219 readings to SD log
Added battery current reading to telemetry
Reworked SD logging: now uses a `std::string` as a buffer, making it possible to use a single `fprintf()` call to write to the SD card. _Impact on performance was not tested, but it makes more sense this way instead of multiple fprintf's_
